### PR TITLE
Adding a way to flush to display with a temporary LUT, not changing t…

### DIFF
--- a/components/hackerhotel2024-bsp/bsp.c
+++ b/components/hackerhotel2024-bsp/bsp.c
@@ -40,6 +40,7 @@ static hink_t epaper = {
     .screen_width          = EPAPER_WIDTH,
     .screen_height         = EPAPER_HEIGHT,
 };
+static epaper_lut_t cur_lut = lut_1s;
 
 static ledstrip_t ledstrip = {
     .pin = GPIO_LED_DATA,
@@ -578,6 +579,14 @@ hink_t* bsp_get_epaper() {
     return &epaper;
 }
 
+esp_err_t bsp_display_flush_with_lut(epaper_lut_t lut) {
+    epaper_lut_t previous = bsp_cur_lut();
+    bsp_apply_lut(lut);
+    esp_err_t err = bsp_display_flush();
+    bsp_apply_lut(previous);
+    return err;
+}
+
 esp_err_t bsp_display_flush() {
     if (!epaper_ready)
         return ESP_FAIL;
@@ -630,7 +639,15 @@ void bsp_restart() {
 }
 
 esp_err_t bsp_apply_lut(epaper_lut_t lut_type) {
-    return hink_apply_lut(&epaper, lut_type);
+    esp_err_t err = hink_apply_lut(&epaper, lut_type);
+    if (err == ESP_OK) {
+        cur_lut = lut_type;
+    }
+    return err;
+}
+
+epaper_lut_t bsp_cur_lut(void) {
+    return cur_lut;
 }
 
 bool bsp_wait_for_button() {

--- a/components/hackerhotel2024-bsp/include/bsp.h
+++ b/components/hackerhotel2024-bsp/include/bsp.h
@@ -56,6 +56,18 @@ esp_err_t bsp_display_message(const char* title, const char* message);
 
 hink_t* bsp_get_epaper();
 
+/** \brief Flushes the framebuffer to the epaper display with a temporary LUT. Restores previous LUT after refresh.
+ *
+ * \details Flushes the framebuffer to the epaper display with a temporary LUT. Restores previous LUT after refresh.
+ *
+ * \retval ESP_OK   The function succesfully executed
+ * \retval ESP_FAIL The function failed, possibly indicating hardware failure
+ *
+ * Check the esp_err header file from the ESP-IDF for a complete list of error codes
+ * returned by SDK functions.
+ */
+ esp_err_t bsp_display_flush_with_lut(epaper_lut_t lut);
+
 /** \brief Flushes the framebuffer to the epaper display
  *
  * \details Flushes the framebuffer to the epaper display.
@@ -117,6 +129,13 @@ void bsp_restart();
  */
 
 esp_err_t bsp_apply_lut(epaper_lut_t lut_type);
+
+/** \brief Get current LUT for the epaper screen
+ *
+ * \details Get current LUT for the epaper screen
+ */
+
+epaper_lut_t bsp_cur_lut(void);
 
 /** \brief Wait for a button to be pressed
  *

--- a/main/main.c
+++ b/main/main.c
@@ -178,6 +178,15 @@ void app_main(void) {
     };
     bsp_sao_addressable_led_set(saoleddata, sizeof(saoleddata));
 
+    enum _epaper_lut lut = lut_1s;
+    esp_err_t err = nvs_get_u8_wrapped("system", "lut", (uint8_t*)&lut);
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "Restoring active LUT to %d", lut);
+        bsp_apply_lut(lut);
+    } else {
+        ESP_LOGE(TAG, "Failed to restore LUT: %s", esp_err_to_name(err));
+    }
+
     // Main application
     screen_t current_screen = screen_pointclick;
     if (release_type == production)

--- a/main/modules/screen_home.c
+++ b/main/modules/screen_home.c
@@ -157,7 +157,7 @@ void DisplayHomeEntry(int cursor) {
     //     screen_pos[cursor][1],
     //     0
     // );
-    bsp_display_flush();
+    bsp_display_flush_with_lut(lut_1s);
 }
 
 screen_t screen_Nametag(QueueHandle_t application_event_queue, QueueHandle_t keyboard_event_queue) {
@@ -200,7 +200,7 @@ screen_t screen_Nametag(QueueHandle_t application_event_queue, QueueHandle_t key
     pax_background(gfx, WHITE);
     AddSWtoBufferLR("Map", "Rename");
     pax_draw_text(gfx, RED, font1, scale, (290 - dims.x) / 2, (100 - dims.y) / 2, nickname);
-    bsp_display_flush();
+    bsp_display_flush_with_lut(lut_8s);
 
     InitKeyboard(keyboard_event_queue);
     configure_keyboard_presses(keyboard_event_queue, true, false, false, false, true);

--- a/main/modules/screen_settings.c
+++ b/main/modules/screen_settings.c
@@ -515,6 +515,9 @@ screen_t screen_lut_dial(QueueHandle_t application_event_queue, QueueHandle_t ke
             default: break;
         }
 
+        bsp_apply_lut(activeLut);
+        nvs_set_u8_wrapped("system", "lut", (uint8_t) activeLut);
+
         event_t event = {0};
         if (xQueueReceive(application_event_queue, &event, portMAX_DELAY) == pdTRUE) {
             switch (event.type) {


### PR DESCRIPTION
…he user-configured one.

Didn't change the apps, with the exception of the nametag app. Homescreen refreshes in 1s now, and nametag uses 8s to have a neat nickname quality.