### PR TITLE
Fix typing lowercase letters

### DIFF
--- a/main/tasks/task_keyboard.c
+++ b/main/tasks/task_keyboard.c
@@ -266,7 +266,7 @@ else if ((state->button_state_left && state->button_state_right && state->enable
             leds      |= LED_M + LED_N + LED_O + LED_P + LED_H + LED_L;
         }
 
-        if (character >= 'a' && character <= 'z' && !state->capslock) {
+        if (character >= 'A' && character <= 'Z' && !state->capslock) {
             character += 32;  // replace uppercase character with lowercase character
         }
     }


### PR DESCRIPTION
The check when to make the letters uppercase had its logic wrong. In the function the characters are uppercase by default and have to be made lowercase further on. The comparison compared the characters to their lowercase counterparts, which can never be true.