### PR TITLE
Fix exit button in Library

### DIFF
--- a/main/modules/screen_library.c
+++ b/main/modules/screen_library.c
@@ -354,6 +354,7 @@ screen_t screen_library_entry(QueueHandle_t application_event_queue, QueueHandle
                     }
                     ESP_LOGE(TAG, "Cursor %d", cursor);
                     DisplayLibraryEntry(cursor);
+                    configure_keyboard_presses(keyboard_event_queue, true, false, false, false, true);
                     configure_keyboard_rotate_both(keyboard_event_queue, SWITCH_3, true);
                     break;
                 default: ESP_LOGE(TAG, "Unhandled event type %u", event.type);


### PR DESCRIPTION
When library screen starts, keyboard_event_queue is called to enable SWITCH_1 and SWITCH_5. When SWITCH_5 is pressed, screen_library_content disables SWITCH_1. For content with more than one page, the switch is re-enabled by Display_library_content(), but for content with a single page, it returns to screen_home_entry with SWITCH_1 still disabled, which causes the exit function to stop working.

This PR resets the state of the enabled buttons upon returning from the content screen.