### PR TITLE
Fix cve-2024-21875

### DIFF
--- a/main/modules/screen_billboard.c
+++ b/main/modules/screen_billboard.c
@@ -110,10 +110,11 @@ void DisplayBillboard(int _addmessageflag, char* _nickname, char* _message) {
         strcpy(messagearray[messagecursor], _message);
 
         // increment or reset cursor
-        if (messagecursor >= nbmessages) {
+        if (messagecursor >= nbmessages - 1) {
             messagecursor = 0;
+        } else {
+            messagecursor++;
         }
-        messagecursor++;
     }
 
     for (int i = 0; i < nbmessages; i++) {


### PR DESCRIPTION
Fix cve-2024-21875 caused by a buffer overflow due to invalid bounds checking